### PR TITLE
Update issue templates to point to new resources

### DIFF
--- a/.github/ISSUE_TEMPLATE/offboard.md
+++ b/.github/ISSUE_TEMPLATE/offboard.md
@@ -16,13 +16,13 @@ If you're reading this, then it's finally time to say goodbye. :sob: We're sad t
 - [ ] Schedule an informal exit chat with your supervisor.
 - [ ] Email [HR](assessor.ccaohr@cookcountyil.gov) to confirm your last day.
 - [ ] Delete any stored CCAO read-only database credentials on your local machine (if applicable).
-- [ ] Email the Chief Data Officer, Directors, and Senior Data Scientists:
+- [ ] Email the Chief Data Officer and Directors:
   - A reminder to change the permissions on your GitHub account and remove you from any relevant GitHub teams
   - A reminder to revoke any private API/deploy keys
   - A reminder to revoke any relevant AWS permissions
   - Your contact information, in case we need to follow-up on something you worked on
-  - A reminder to add you to the [list of former interns and employees used to generate model names](https://github.com/ccao-data/ccao/blob/master/data-raw/ccao_ids.R)
-- [ ] Deliver your wrap-up memo (see below) to your project lead and the CDO via email
+  - A reminder to add you to the [list of former interns and employees used to generate model names](https://github.com/ccao-data/data-architecture/blob/master/dbt/seeds/ccao/ccao.person.csv)
+- [ ] Deliver your wrap-up memo (see below) to your project lead and the CDO via PR
 
 # Memo
 
@@ -35,7 +35,7 @@ In addition to the items above, we ask that you write up a short (one page) docu
 - Links to the relevant repository and/or issues
 - Any remaining next steps
 
-Upon completion, anticipate the memo will be sent by the project lead/CDO to other executives, such as the Chief of Staff and the Assessor.
+The memo should be submitted as a pull request to the [CCAO blog repository](https://github.com/ccao-data/blog). See that repository for examples of previous intern memos and their format. Upon completion, anticipate the memo will be sent by the project lead/CDO to other executives, such as the Chief of Staff and the Assessor.
 
 If you so choose, the memo may also be used as the basis for a Data Department blog post, which will publicly summarize your work. We will share this post with you upon completion. If you do not wish to be featured in public posts, leave the boxes below unchecked.
 

--- a/.github/ISSUE_TEMPLATE/onboard-internal.md
+++ b/.github/ISSUE_TEMPLATE/onboard-internal.md
@@ -53,8 +53,8 @@ If you plan to work remotely, you will need to use the county VPN to access inte
 Interns and staff need to obtain a County employee ID badge and activate it. The badge grants access to the 9th floor via elevator. To obtain an ID badge, perform the following steps after the you've been added to the payroll system:
 
 - [ ] Go to the Cook County Bureau of Human Resources, on the 8th floor in room 834 of the County building. The HR office is open Monday-Thursday, 9am-2pm. Your photo will be taken and your card promptly printed.
-- [ ] Email the CCAO's Manager of Payroll to inform them that you have your County employee ID. 
-- [ ] Fill out and return any paperwork provided by the Manager of Payroll. 
+- [ ] Email the CCAO's Manager of Payroll to inform them that you have your County employee ID.
+- [ ] Fill out and return any paperwork provided by the Manager of Payroll.
 
 ## Teams
 
@@ -149,7 +149,7 @@ All new hires, interns, and fellows are required to read the following:
 - [ ] [Data Department Glossary](https://github.com/ccao-data/wiki/blob/master/Handbook/Glossary.md) - The CCAO uses a lot of assessment- and office-specific jargon. Read through this glossary to get acquainted with some of the terms.
 - [ ] [Data Department Data Catalog](https://ccao-data.github.io/data-architecture) - Architecture overview and database documentation for all Data Department assets. Read through the landing page and explore the data catalog a bit.
 
-Additionally, take a moment to bookmark all the links marked with a :exclamation: under the "Useful Bookmarks" section of the [Resources](https://github.com/ccao-data/wiki/blob/master/Handbook/Resources.md) page.
+Additionally, take a moment to visit the [internal org-level README](https://github.com/ccao-data?view_as=member) and investigate the listed services. We highly recommend you use this page as your entrypoint to all work at the CCAO.
 
 If you have downtime while working, we highly recommend reading anything marked with a :star: on the [Resources](https://github.com/ccao-data/wiki/blob/master/Handbook/Resources.md) page.
 


### PR DESCRIPTION
Just some quick maintenance on the onboarding/offboarding issue templates to point to the most recent resources.