### PR TITLE
Augment onboarding issue templates with links to local dev environment setup docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/onboard-internal.md
+++ b/.github/ISSUE_TEMPLATE/onboard-internal.md
@@ -118,13 +118,19 @@ You will be issued a CCAO laptop as part of your onboarding. This laptop has all
 
 ## Server Setup
 
-For actual coding and computation, the Data Department uses an on-premise server. The server can be accessed via SSH, RStudio, or JupyterLab as long as you are connected to the county VPN. To gain access to the server, you will need an account.
+The Data Department often uses an on-premise server for programming tasks that require intensive compute. The server can be accessed via SSH, RStudio, or Positron as long as you are connected to the county VPN. To gain access to the server, you will need an account.
 
 - [ ] Send a Teams message to Jean ([@jeancochrane](https://github.com/jeancochrane)) requesting an RStudio/server account.
 
-Once your account is created, you can connect to the server via [RStudio](https://datascience.cookcountyassessor.com/rstudio/) or [JupyterLab](https://datascience.cookcountyassessor.com/jupyter).
+Once your account is created, you can connect to the server via [RStudio](https://datascience.cookcountyassessor.com/rstudio/) or your local Positron app using a [remote SSH connection](https://positron.posit.co/remote-ssh).
 
-- [ ] Successfully login to either [RStudio](https://datascience.cookcountyassessor.com/rstudio) or [JupyterLab](https://datascience.cookcountyassessor.com/jupyter).
+- [ ] Successfully login to the server using either [RStudio](https://datascience.cookcountyassessor.com/rstudio), Positron with a remote SSH connection, or a terminal.
+
+## Dev Environment Setup
+
+The Data Department often uses our laptops for programming tasks that **do not** require intensive compute. The line between intensive and non-intensive tasks is not always clear, so the choice to complete a task on the server or on your laptop often comes down to personal preference.
+
+- [ ] Follow our instructions for [setting up your dev environment](https://github.com/ccao-data/wiki/blob/master/Handbook/Dev-Environment-Setup.md). (Interns who plan to do all their work on the server in RStudio or Positron can skip this step.)
 
 ## Projects and Git
 

--- a/.github/ISSUE_TEMPLATE/onboard-internal.md
+++ b/.github/ISSUE_TEMPLATE/onboard-internal.md
@@ -126,11 +126,11 @@ Once your account is created, you can connect to the server via [RStudio](https:
 
 - [ ] Successfully login to the server using either [RStudio](https://datascience.cookcountyassessor.com/rstudio), Positron with a remote SSH connection, or a terminal.
 
-## Dev Environment Setup
+## Local Dev Environment Setup
 
 The Data Department often uses our laptops for programming tasks that **do not** require intensive compute. The line between intensive and non-intensive tasks is not always clear, so the choice to complete a task on the server or on your laptop often comes down to personal preference.
 
-- [ ] Follow our instructions for [setting up your dev environment](https://github.com/ccao-data/wiki/blob/master/Handbook/Dev-Environment-Setup.md). (Interns who plan to do all their work on the server in RStudio or Positron can skip this step.)
+- [ ] Follow our instructions for [setting up your local dev environment](https://github.com/ccao-data/wiki/blob/master/Handbook/Local-Dev-Environment-Setup.md). (Interns who plan to do all their work on the server in RStudio or Positron can skip this step.)
 
 ## Projects and Git
 

--- a/.github/ISSUE_TEMPLATE/onboard-returning.md
+++ b/.github/ISSUE_TEMPLATE/onboard-returning.md
@@ -13,7 +13,7 @@ Welcome back! This issue ticket serves as a checklist for your return to the CCA
 - [ ] Verify that you have VPN access.
 - [ ] Verify that your County employee ID badge grants access to 9th floor.
 - [ ] Verify that you're able to send messages in Teams.
-- [ ] If you're using a local machine (i.e. your laptop), follow our instructions for [setting up your local dev environment](https://github.com/ccao-data/wiki/blob/master/Handbook/Dev-Environment-Setup.md).
+- [ ] If you're using a local machine (i.e. your laptop), follow our instructions for [setting up your local dev environment](https://github.com/ccao-data/wiki/blob/master/Handbook/Local-Dev-Environment-Setup.md).
 - [ ] If you're using a local machine, validate your git configuration (make sure you can push and pull).
 - [ ] **Interns only:** Email your preferred schedule to [Nicole](mailto:nicole.jardine@cookcountyil.gov) and [Dan](mailto:daniel.snow@cookcountyil.gov). Include the days and times you will be working and the date of your last day. Subject: 'YOUR NAME - Internship Hours'
 

--- a/.github/ISSUE_TEMPLATE/onboard-returning.md
+++ b/.github/ISSUE_TEMPLATE/onboard-returning.md
@@ -13,7 +13,7 @@ Welcome back! This issue ticket serves as a checklist for your return to the CCA
 - [ ] Verify that you have VPN access.
 - [ ] Verify that your County employee ID badge grants access to 9th floor.
 - [ ] Verify that you're able to send messages in Teams.
-- [ ] If you're using a local machine, install the latest versions of [R](https://cloud.r-project.org/) and [RStudio](https://posit.co/download/rstudio-desktop/#download).
+- [ ] If you're using a local machine, follow our instructions for [setting up your dev environment](https://github.com/ccao-data/wiki/blob/master/Handbook/Dev-Environment-Setup.md).
 - [ ] If you're using a local machine, validate your git configuration (make sure you can push and pull).
 - [ ] **Interns only:** Email your preferred schedule to [Nicole](mailto:nicole.jardine@cookcountyil.gov) and [Dan](mailto:daniel.snow@cookcountyil.gov). Include the days and times you will be working and the date of your last day. Subject: 'YOUR NAME - Internship Hours'
 

--- a/.github/ISSUE_TEMPLATE/onboard-returning.md
+++ b/.github/ISSUE_TEMPLATE/onboard-returning.md
@@ -13,7 +13,7 @@ Welcome back! This issue ticket serves as a checklist for your return to the CCA
 - [ ] Verify that you have VPN access.
 - [ ] Verify that your County employee ID badge grants access to 9th floor.
 - [ ] Verify that you're able to send messages in Teams.
-- [ ] If you're using a local machine, follow our instructions for [setting up your dev environment](https://github.com/ccao-data/wiki/blob/master/Handbook/Dev-Environment-Setup.md).
+- [ ] If you're using a local machine (i.e. your laptop), follow our instructions for [setting up your local dev environment](https://github.com/ccao-data/wiki/blob/master/Handbook/Dev-Environment-Setup.md).
 - [ ] If you're using a local machine, validate your git configuration (make sure you can push and pull).
 - [ ] **Interns only:** Email your preferred schedule to [Nicole](mailto:nicole.jardine@cookcountyil.gov) and [Dan](mailto:daniel.snow@cookcountyil.gov). Include the days and times you will be working and the date of your last day. Subject: 'YOUR NAME - Internship Hours'
 


### PR DESCRIPTION
This PR updates our onboarding issue templates to link out to the new local dev environment setup docs that we are adding in https://github.com/ccao-data/wiki/pull/71.

Closes https://github.com/ccao-data/people/issues/33.